### PR TITLE
Add bilmur script for RUM data collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # wc-usage-tracking-auto-opt-in
-Automatically opts site into WooCommerce Usage Tracking and Sensei Usage Tracking
+Automatically opts site into:
+- WooCommerce Usage Tracking
+- Sensei Usage Tracking
+- Bilmur RUM data collector
 
 This plugin would work well as an mu-plugin that is auto-loaded into new sites upon site creation.
 

--- a/wc-usage-tracking-auto-opt-in.php
+++ b/wc-usage-tracking-auto-opt-in.php
@@ -35,3 +35,27 @@ add_filter(
 		return $values;
 	}
 );
+
+/**
+ * Bilmur RUM data collector
+ */
+add_action(
+	'wp_enqueue_scripts',
+	function() {
+		wp_enqueue_script( 'bilmur', 'https://s0.wp.com/wp-content/js/bilmur.min.js?m=202215', array(), '1.0.0', true );
+	}
+);
+
+add_filter(
+	'script_loader_tag',
+	function( $tag, $handle ) {
+		if ( 'bilmur' !== $handle ) {
+			return $tag;
+		}
+
+		// TODO: Values for provider and service TBD. Here's the placeholder for now.
+		return str_replace( ' src', ' data-provider="" data-service="" src', $tag );
+	},
+	10,
+	2
+);


### PR DESCRIPTION
This change comes  from the Site Performance Metrics Task Force:
https://to51.wordpress.com/2023/01/16/pt-task-force-site-performance-metrics/#comment-30841

The change here adds a JS script for Real User Monitoring (RUM).

The plugin was added as a `mu-plugin` on https://adamswineshop-development.mystagingwebsite.com/ and it's showing the tracking data on Logstash [here](https://logstash.a8c.com/logstash/goto/5eb782ce0dc1472cae9ce69181f447b8).

<img width="1540" alt="Screen Shot 2023-03-24 at 10 24 31" src="https://user-images.githubusercontent.com/1821060/227583999-7dc7661a-649f-4769-8a9a-d25b656b24ff.png">
